### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <!-- Copyright © 2013-2016 Galvanized Logic Inc.                       -->
 <!-- Use is governed by a BSD-style license found in the LICENSE file. -->
 
-#Vu
+# Vu
 
 Vu (Virtual Universe) is an agile 3D engine based on the modern programming
 language Go (Golang). Vu is composed of packages, detailed in [GoDoc](http://godoc.org/github.com/gazed/vu),


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
